### PR TITLE
Allow clients to specify addr

### DIFF
--- a/cmd/go-cache-plugin/commands.go
+++ b/cmd/go-cache-plugin/commands.go
@@ -169,12 +169,17 @@ func runServe(env *command.Env) error {
 
 // runConnect implements a direct cache proxy by connecting to a remote server.
 func runConnect(env *command.Env, plugin string) error {
-	port, err := strconv.Atoi(plugin)
-	if err != nil {
-		return fmt.Errorf("invalid plugin port: %w", err)
+	addr := plugin
+	if strings.Contains(plugin) {
+		port, err := strconv.Atoi(plugin)
+		if err != nil {
+			return fmt.Errorf("invalid plugin port: %w", err)
+		}
+
+		addr = fmt.Sprintf(":%d", port)
 	}
 
-	conn, err := net.Dial("tcp", fmt.Sprintf(":%d", port))
+	conn, err := net.Dial("tcp", addr)
 	if err != nil {
 		return fmt.Errorf("dial: %w", err)
 	}

--- a/cmd/go-cache-plugin/commands.go
+++ b/cmd/go-cache-plugin/commands.go
@@ -170,7 +170,9 @@ func runServe(env *command.Env) error {
 // runConnect implements a direct cache proxy by connecting to a remote server.
 func runConnect(env *command.Env, plugin string) error {
 	addr := plugin
-	if strings.Contains(plugin) {
+
+	// If the caller has not specified a host/port, then likely this is an older usage which only specifies port
+	if !strings.Contains(plugin, ":") {
 		port, err := strconv.Atoi(plugin)
 		if err != nil {
 			return fmt.Errorf("invalid plugin port: %w", err)


### PR DESCRIPTION
```
go test ./...
?   	github.com/grafana/go-cache-plugin/cmd/go-cache-plugin	[no test files]
?   	github.com/grafana/go-cache-plugin/lib/gobuild	[no test files]
?   	github.com/grafana/go-cache-plugin/lib/modproxy	[no test files]
?   	github.com/grafana/go-cache-plugin/lib/revproxy	[no test files]
ok  	github.com/grafana/go-cache-plugin/lib/s3util	(cached)
```